### PR TITLE
Refactor and add new services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -39,5 +39,6 @@ AWS::S3::Bucket
 AWS::SNS::Topic
 AWS::SQS::Queue
 AWS::SSM::Parameter
+AWS::StepFunctions::StateMachine
 AWS::WAFv2::WebACL
 ```

--- a/README.md
+++ b/README.md
@@ -25,11 +25,19 @@ plugins:
     
 ### Suported AWS resources
 ```
-AWS::Lambda::Function
-AWS::SQS::Queue
-AWS::Kinesis::Stream
-AWS::DynamoDB::Table
-AWS::S3::Bucket
+AWS::ApiGateway::RestApi
 AWS::ApiGateway::Stage
+AWS::ApiGatewayV2::Api
+AWS::ApiGatewayV2::Stage
 AWS::CloudFront::Distribution
+AWS::DynamoDB::Table
+AWS::IAM::Role
+AWS::Kinesis::Stream
+AWS::Lambda::Function
+AWS::Logs::LogGroup
+AWS::S3::Bucket
+AWS::SNS::Topic
+AWS::SQS::Queue
+AWS::SSM::Parameter
+AWS::WAFv2::WebACL
 ```

--- a/index.js
+++ b/index.js
@@ -1,111 +1,136 @@
 'use strict';
 
-const _ = require('underscore');
-
 class ServerlessPlugin {
-  constructor(serverless, options) {
+  constructor(serverless) {
     this.serverless = serverless;
-    this.options = options || {};
     this.provider = serverless ? serverless.getProvider('aws') : null;
     this.service = serverless.service;
-    this.stage = null;
-    this.region = null;
-    this.isApiGatewayStageAvailableInTemplate = false;
-    this.supportedTypes = [
-      "AWS::Lambda::Function",
-      "AWS::SQS::Queue",
-      "AWS::Kinesis::Stream",
-      "AWS::DynamoDB::Table",
-      "AWS::S3::Bucket",
-      "AWS::ApiGateway::Stage",
-      "AWS::CloudFront::Distribution"
+    this.listTagsResources = [
+      'AWS::ApiGateway::RestApi',
+      'AWS::ApiGateway::Stage',
+      'AWS::CloudFront::Distribution',
+      'AWS::DynamoDB::Table',
+      'AWS::IAM::Role',
+      'AWS::Kinesis::Stream',
+      'AWS::Lambda::Function',
+      'AWS::S3::Bucket',
+      'AWS::SNS::Topic',
+      'AWS::SQS::Queue',
+      'AWS::WAFv2::WebACL',
     ];
+    this.objectTagsResources = [
+      'AWS::ApiGatewayV2::Api',
+      'AWS::ApiGatewayV2::Stage',
+      'AWS::SSM::Parameter',
+    ];
+    this.programmaticTagsResources = {
+      'AWS::Logs::LogGroup': this._addTagsToLogsLogGroup.bind(this), // see https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/pull/53
+    };
 
     if (!this.provider) {
       throw new Error('This plugin must be used with AWS');
     }
 
     this.hooks = {
-      'deploy:finalize': this._addAPIGatewayStageTags.bind(this),
-      'after:deploy:deploy': this._addTagsToResource.bind(this),
-      'after:aws:package:finalize:mergeCustomProviderResources': this._addTagsToResource.bind(this)
+      'after:aws:package:finalize:mergeCustomProviderResources': this._addTagsToResources.bind(this),
+      'after:deploy:deploy': this._addTagsProgrammatically.bind(this),
     };
   }
 
-  _addTagsToResource() {
-    var stackTags = [];
-    var self = this;
+  _addTagsToResources() {
+    const stackTags = this._getStackTags();
+    if (stackTags.length === 0) {
+      this.serverless.cli.log('No stack tags, not updating AWS resource tags');
+      return;
+    }
+
     const template = this.serverless.service.provider.compiledCloudFormationTemplate;
 
+    Object.keys(template.Resources).forEach((key) => {
+      const resourceType = template.Resources[key]['Type'];
+      const properties = template.Resources[key]['Properties'];
 
-    this.stage = this.serverless.service.provider.stage;
-    if (this.options.stage) {
-      this.stage = this.options.stage;
-    }
-
-    this.region = this.serverless.service.provider.region;
-    if (this.options.region) {
-      this.region = this.options.region;
-    }
-
-    if (typeof this.serverless.service.provider.stackTags === 'object') {
-      var tags = this.serverless.service.provider.stackTags
-      Object.keys(tags).forEach(function (key) {
-        stackTags.push({ "Key": key, "Value": tags[key] })
-      });
-    }
-
-    Object.keys(template.Resources).forEach(function (key) {
-      var resourceType = template.Resources[key]['Type']
-      if ((self.supportedTypes.indexOf(resourceType) !== -1) && Array.isArray(stackTags) && stackTags.length > 0) {
-        if (template.Resources[key]['Properties']) {
-          var tags = template.Resources[key]['Properties']['Tags']
-          if (tags) {
-            template.Resources[key]['Properties']['Tags'] = tags.concat(stackTags.filter(obj => (self._getTagNames(tags).indexOf(obj["Key"]) === -1)))
-          } else {
-            template.Resources[key]['Properties']['Tags'] = stackTags
-          }
-        } else {
-          self.serverless.cli.log('Properties not available for ' + resourceType);
+      if (properties) {
+        if (this.listTagsResources.includes(resourceType)) {
+          const resourceTags = this._readTagsFromList(properties['Tags']);
+          properties['Tags'] = this._mergeTags(resourceTags, stackTags);
+        } else if (this.objectTagsResources.includes(resourceType)) {
+          const resourceTags = this._readTagsFromObject(properties['Tags']);
+          properties['Tags'] = this._tagsListToObject(this._mergeTags(resourceTags, stackTags));
         }
       }
-
-      //Flag to avoid _addAPIGatewayStageTags() call if stage config is available in serverless.yml
-      if (resourceType === "AWS::ApiGateway::Stage") {
-        self.isApiGatewayStageAvailableInTemplate = true;
-      }
     });
-    self.serverless.cli.log('Updated AWS resource tags..');
+
+    this.serverless.cli.log('Updated AWS resource tags');
   }
 
-  _addAPIGatewayStageTags() {
-    var self = this;
-    var stackName = this.provider.naming.getStackName();
-    if (!self.isApiGatewayStageAvailableInTemplate) {
-      return this.provider.request('CloudFormation', 'describeStackResources', { StackName: stackName })
-        .then(function (resp) {
-          var promiseStack = [];
-          _.each(_.filter(resp.StackResources, resource => resource.ResourceType === 'AWS::ApiGateway::RestApi'), function (resource) {
-            var apiStageParams = {
-              resourceArn: 'arn:aws:apigateway:' + self.region + '::/restapis/' + resource.PhysicalResourceId + '/stages/' + self.stage,
-              tags: self.service.provider.stackTags
-            };
-            promiseStack.push(self.provider.request('APIGateway', 'tagResource', apiStageParams))
-          });
-          return Promise.all(promiseStack).then(resp => self.serverless.cli.log('Updated APIGateway resource tags..'));
-        });
-    } else {
-      self.serverless.cli.log('APIGateway stage already available in serverless.yml. Tag update skipped.');
-      return null;
+  async _addTagsProgrammatically() {
+    const stackTags = this._getStackTags();
+    if (stackTags.length === 0) {
+      return;
+    }
+
+    const stackName = this.provider.naming.getStackName();
+    const describeResponse = await this.provider.request('CloudFormation', 'describeStackResources', {StackName: stackName});
+
+    const promises = [];
+
+    const programmaticResourceKeys = Object.keys(this.programmaticTagsResources);
+    describeResponse.StackResources.forEach(resource => {
+      if (programmaticResourceKeys.includes(resource.ResourceType)) {
+        promises.push(
+          this.programmaticTagsResources[resource.ResourceType](resource, stackTags),
+        );
+      }
+    });
+
+    if (promises.length) {
+      await Promise.all(promises);
+      this.serverless.cli.log(`Updated ${promises.length} AWS resource tags programmatically`);
     }
   }
 
-  _getTagNames(srcArray) {
-    var tagNames = []
-    srcArray.forEach(function (element) {
-      tagNames.push(element["Key"])
+  _addTagsToLogsLogGroup(resource, tags) {
+    return this.provider.request('CloudWatchLogs', 'tagLogGroup', {
+      logGroupName: resource.PhysicalResourceId,
+      tags: this._tagsListToObject(tags),
     });
-    return tagNames
+  }
+
+  _readTagsFromList(tags) {
+    return tags || [];
+  }
+
+  _readTagsFromObject(tags) {
+    if (!tags) {
+      return [];
+    }
+
+    return Object.keys(tags).map(key => ({
+      Key: key,
+      Value: tags[key],
+    }));
+  }
+
+  _tagsListToObject(tags) {
+    return tags.reduce((acc, tag) => {
+      acc[tag['Key']] = tag['Value'];
+      return acc;
+    }, {});
+  }
+
+  _mergeTags(resourceTags, stackTags) {
+    return [
+      ...resourceTags,
+      ...stackTags.filter(tag => !resourceTags.map(t => t['Key']).includes(tag['Key'])),
+    ];
+  }
+
+  _getStackTags() {
+    if (typeof this.serverless.service.provider.stackTags === 'object') {
+      return this._readTagsFromObject(this.serverless.service.provider.stackTags);
+    }
+    return [];
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class ServerlessPlugin {
       'AWS::S3::Bucket',
       'AWS::SNS::Topic',
       'AWS::SQS::Queue',
+      'AWS::StepFunctions::StateMachine',
       'AWS::WAFv2::WebACL',
     ];
     this.objectTagsResources = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,5 @@
 {
   "name": "serverless-plugin-resource-tagging",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "user": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/user/-/user-0.0.0.tgz",
-      "integrity": "sha1-8n8bI/xRHyqO+kDbVc+6Ejgk4Co="
-    }
-  }
+  "version": "1.1.1",
+  "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,5 @@
   "bugs": {
     "url": "https://github.com/ilayanambi86/serverless-plugin-resource-tagging/issues"
   },
-  "homepage": "https://github.com/ilayanambi86/serverless-plugin-resource-tagging#readme",
-  "dependencies": {
-    "user": "0.0.0",
-    "underscore": "^1.12.1"
-  }
+  "homepage": "https://github.com/ilayanambi86/serverless-plugin-resource-tagging#readme"
 }


### PR DESCRIPTION
Hey @ilayanambi86 
the trouble with CloudFormation tags not being propagated is real and I like the approach you took with this plugin!

I needed it to support more services. I refactored the code to enable it. The changes I made:

1. Introduce separate lists of resources that accept tags as object, as list, and those that need a programmatic SDK call (not supported by the CloudFormation).
1. Remove code to tag the API Gateway stage - I tested creating the REST API Gtw. and the stage was always tagged with the same tags as the API. Maybe I'm not seeing some edge case - in such a case, I will be happy to restore it.
1. Refactor code in few places to use new array methods and lambda functions to simplify the code, remove unnecessary dependencies.

Please let me know what do you think.