### PR TITLE
Adding AWS::Logs::LogGroup to supported resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,5 @@ AWS::DynamoDB::Table
 AWS::S3::Bucket
 AWS::ApiGateway::Stage
 AWS::CloudFront::Distribution
+AWS::Logs::LogGroup
 ```

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ class ServerlessPlugin {
       "AWS::DynamoDB::Table",
       "AWS::S3::Bucket",
       "AWS::ApiGateway::Stage",
-      "AWS::CloudFront::Distribution"
+      "AWS::CloudFront::Distribution",
+      "AWS::Logs::LogGroup"
     ];
 
     if (!this.provider) {


### PR DESCRIPTION
As Cloudwatch Log groups now support tagging via cloudformation according to [roadmap issue](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/919) and [cloudfromation docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html) I believe it can be added to the supported resources. 
