### PR TITLE
Tag cloudwatch alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@ AWS::ApiGateway::Stage
 AWS::CloudFront::Distribution
 AWS::Logs::LogGroup
 AWS::CloudWatch::Alarm
+AWS::Events::Rule
 ```

--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ AWS::S3::Bucket
 AWS::ApiGateway::Stage
 AWS::CloudFront::Distribution
 AWS::Logs::LogGroup
+AWS::CloudWatch::Alarm
 ```

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ class ServerlessPlugin {
       "AWS::S3::Bucket",
       "AWS::ApiGateway::Stage",
       "AWS::CloudFront::Distribution",
-      "AWS::Logs::LogGroup"
+      "AWS::Logs::LogGroup",
+      "AWS::CloudWatch::Alarm"
     ];
 
     if (!this.provider) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ class ServerlessPlugin {
       "AWS::ApiGateway::Stage",
       "AWS::CloudFront::Distribution",
       "AWS::Logs::LogGroup",
-      "AWS::CloudWatch::Alarm"
+      "AWS::CloudWatch::Alarm",
+      "AWS::Events::Rule"
     ];
 
     if (!this.provider) {


### PR DESCRIPTION
Adding AWS::CloudWatch::Alarm & AWS::Events::Rule to supported resources so that cloudwatch alarms and cron rules created by serverless stack  are tagged e.g. on step functions.